### PR TITLE
Fix cosine pairwise matrix

### DIFF
--- a/fastdist/fastdist.py
+++ b/fastdist/fastdist.py
@@ -328,9 +328,11 @@ def cosine_pairwise_distance(a, return_matrix=False):
     if return_matrix:
         out_mat = np.zeros((n, n))
         for i in range(n):
-            for j in range(n):
+            for j in range(i):
                 out_mat[i][j] = np.dot(a[i], a[j])
-        return out_mat + out_mat.T
+        out_mat += out_mat.T
+        np.fill_diagonal(out_mat,1) 
+        return out_mat
     else:
         out = np.zeros((len(perm), 1))
         for i in range(len(perm)):


### PR DESCRIPTION
Small fix in the cosine_pairwise_matrix calculation.
I fixed the loop range so it doesn't run on all samples twice and adjusted the final matrix accordingly.

You may also want to consider changing the cosine similarity to cosine distance across the entire code for consistency with other metrics where the distance is zero for identical values. Alternatively the names should be changed (e.g. cosine_pairwise_similarity) to avoid confusion.